### PR TITLE
fix: syntax highlight and error handling

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -865,38 +865,35 @@ async function validateBuild(document: TextDocument): Promise<void> {
         const line = lines[i];
         
         // Match error message.
-        const errorMatch = line.match(/^error: (.+)$/);
+        const errorMatch = line.match(/^error:\s*(.+?)\s+-->\s+(\d+):(\d+)/);
         if (errorMatch) {
           let message = errorMatch[1];
-          
-          // Match location.
-          const locationMatch = lines[i + 1]?.match(/┌─ (.+):(\d+):(\d+)$/);
-          if (locationMatch) {
-            const [_, file, lineStr, colStr] = locationMatch;
-            const lineNum = parseInt(lineStr) - 1;
-            const col = parseInt(colStr) - 1;
+          const lineNum = parseInt(errorMatch[2]) - 1;
+          const col = parseInt(errorMatch[3]) - 1;
 
-            // Match additional error details.
-            for (let j = i + 2; j < lines.length; j++) {
-              const detailMatch = lines[j]?.match(/\^+\s*(.+)$/);
-              if (detailMatch) {
-                message += '\n\n' + detailMatch[1];
-                break;
-              }
+          let filePath: string | null = null;
+          for (let j = i + 1; j < lines.length; j++) {
+            const detailMatch = lines[j]?.match(/^\s*=\s+(.+)$/);
+            if (detailMatch) {
+              message = message.replace(/:?\s*$/, '') + ': ' + detailMatch[1];
             }
-
-            if (document.uri.endsWith(file)) {
-              const position = Position.create(lineNum, col);
-              const range = getWordRangeAtPosition(document, position);
-
-              diagnostics.push({
-                severity: DiagnosticSeverity.Error,
-                range,
-                message,
-                source: "solana-ebpf",
-                code: "build-error",
-              });
+            const fileMatch = lines[j]?.match(/┌─\s+(.+?):\d+:\d+$/);
+            if (fileMatch) {
+              filePath = fileMatch[1];
+              break;
             }
+          }
+
+          if (filePath && document.uri.endsWith(filePath)) {
+            const position = Position.create(lineNum, col);
+            const range = getWordRangeAtPosition(document, position);
+            diagnostics.push({
+              severity: DiagnosticSeverity.Error,
+              range,
+              message,
+              source: "solana-ebpf",
+              code: "build-error",
+            });
           }
         }
       }

--- a/syntaxes/sbpf-asm.tmLanguage.json
+++ b/syntaxes/sbpf-asm.tmLanguage.json
@@ -40,13 +40,25 @@
           {
             "match": "\\.(?:extern|section|globl|global|rodata|ascii|asciz)",
             "name": "storage.type.class.sbpf-asm"
+          },
+          {
+            "match": "\\b(?:u8|u16|u32|u64)\\b",
+            "name": "storage.type.size.sbpf-asm"
+          },
+          {
+            "match": "\\bif\\b",
+            "name": "keyword.control.sbpf-asm"
+          },
+          {
+            "match": "\\bll\\b",
+            "name": "keyword.other.sbpf-asm"
           }
         ]
       },
       "opcodes": {
         "patterns": [
           {
-            "match": "\\b(?:add|and|arsh|div|lmul|lsh|mod|mov|mul|neg|or|rsh|sdiv|shmul|srem|sub|udiv|uhmul|urem|xor)(32|64)\\b|\\b(?:be|call|exit|hor64|j(?:a|eq|ge|gt|le|lt|ne)|js(?:et|ge|gt|le|lt)|ld(?:b|h|w|dw)|ldx(?:b|h|w|dw)|le|st(?:b|h|w|dw)|stx(?:b|h|w|dw))\\b",
+            "match": "\\b(?:add|and|arsh|div|lmul|lsh|mod|mov|mul|neg|or|rsh|sdiv|shmul|srem|sub|udiv|uhmul|urem|xor)(32|64)\\b|\\b(?:be(?:16|32|64)?|call(?:x)?|exit|goto|hor64|j(?:a|eq|ge|gt|le|lt|ne)|js(?:et|ge|gt|le|lt)|ld(?:b|h|w|dw)|ldx(?:b|h|w|dw)|le(?:16|32|64)?|st(?:b|h|w|dw)|stx(?:b|h|w|dw))\\b",
             "name": "keyword.opcode.sbpf-asm"
           }
         ]
@@ -54,7 +66,7 @@
       "registers": {
         "patterns": [
           {
-            "match": "\\b[r][0-9]{1,2}\\b",
+            "match": "\\b[rw][0-9]{1,2}\\b",
             "name": "variable.register.sbpf-asm"
           }
         ]


### PR DESCRIPTION
### Summary

1. Update syntax to highlight llvm assembly dialect
2. Fix error handling

Example:

<img width="669" height="513" alt="Screenshot 2026-04-09 at 10 28 24 PM" src="https://github.com/user-attachments/assets/e7c9f6ec-dc3c-4d35-a47c-5a2efdeb8759" />


